### PR TITLE
tech(command): include --directory option

### DIFF
--- a/recipes/index.js
+++ b/recipes/index.js
@@ -7,11 +7,11 @@ const {
 } = require("./utils");
 const install = require('./install');
 
-program.option("-f, --app-name <value>", "App Name");
-program.parse(process.argv);
+program.option("-d, --directory <value>", "Use directory");
+program.parse();
 
-//pre install check
 const appName = program.args[0];
+const directory = program.opts().directory;
 
 if (!appName) {
   console.error("Please specify the app name:");
@@ -34,4 +34,4 @@ if (!appName) {
   error("App name is missing");
 }
 
-install(appName);
+install(appName,directory);

--- a/recipes/install.js
+++ b/recipes/install.js
@@ -17,7 +17,7 @@ const {
   moduleSetInstall,
 } = require("./utils");
 
-const install = function(appName) {
+const install = function(appName,directory) {
   CFonts.say("React Chef", {
     type: 5,
     font: "block", // define the font face
@@ -49,9 +49,12 @@ const install = function(appName) {
 
   tryAccess(baseDirPath)
     .then(() => {}, function onPathExist() {
-      error(
-        `Choose different App name. ${appName} is already exist in ${process.cwd()}`
-      );
+      if(directory === undefined){
+        error(
+          `Choose different App name. ${appName} is already exist in ${process.cwd()}`
+        );
+      }
+      return true;
     })
     .then(() => {
       return inquirer.prompt([
@@ -132,8 +135,12 @@ const install = function(appName) {
       return inquirer.prompt(projectQuestions);
     })
     .then((answers) => {
-      shell.mkdir(baseDirPath);
-      shell.cd(appName);
+      if(directory === undefined) {
+        shell.mkdir(baseDirPath);
+        shell.cd(appName);
+      } else {
+        shell.cd(directory);
+      }
       shell.exec("npm init -y", { silent: true });
 
       return answers;

--- a/recipes/install.js
+++ b/recipes/install.js
@@ -49,7 +49,7 @@ const install = function(appName,directory) {
 
   tryAccess(baseDirPath)
     .then(() => {}, function onPathExist() {
-      if(directory === undefined){
+      if(!directory){
         error(
           `Choose different App name. ${appName} is already exist in ${process.cwd()}`
         );
@@ -135,7 +135,7 @@ const install = function(appName,directory) {
       return inquirer.prompt(projectQuestions);
     })
     .then((answers) => {
-      if(directory === undefined) {
+      if(!directory) {
         shell.mkdir(baseDirPath);
         shell.cd(appName);
       } else {


### PR DESCRIPTION
#16 

- A new option added to the `react-chef ` command
- Restructure the command as per commander standard

To set up the project

~~npx react-chef -c <your-app-name>~~

```
npx react-chef <your-app-name>
```

To set up in the existing folder

~~npx react-chef -c <your-app-name> -d <relative-path>~~
```
npx react-chef <your-app-name> -d <relative-path>
```